### PR TITLE
Create extension to support Slim templates on RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,19 @@
+require:
+  - rubocop-slim
+
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
+  Exclude:
+    - spec/**/*.slim
   NewCops: enable
   TargetRubyVersion: 2.6
 
 Metrics:
   Enabled: false
+
+Naming/FileName:
+  Exclude:
+    - lib/rubocop-slim.rb

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ gemspec
 
 gem 'rake'
 gem 'rspec'
-gem 'rubocop'
+gem 'rubocop', github: 'r7kamura/rubocop', branch: 'feature/template-support'
 gem 'rubocop-rake'
 gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,25 @@
+GIT
+  remote: https://github.com/r7kamura/rubocop.git
+  revision: 9267fef7f6055bc141340164ac13bcd6b9f35de1
+  branch: feature/template-support
+  specs:
+    rubocop (1.32.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.19.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+
 PATH
   remote: .
   specs:
     rubocop-slim (0.1.0)
+      rubocop (~> 1.32)
+      slimi (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -29,16 +47,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.32.0)
-      json (~> 2.3)
-      parallel (~> 1.10)
-      parser (>= 3.1.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
     rubocop-rake (0.6.0)
@@ -46,6 +54,13 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    slimi (0.7.2)
+      temple
+      thor
+      tilt
+    temple (0.8.2)
+    thor (1.2.1)
+    tilt (2.0.11)
     unicode-display_width (2.2.0)
 
 PLATFORMS
@@ -54,7 +69,7 @@ PLATFORMS
 DEPENDENCIES
   rake
   rspec
-  rubocop
+  rubocop!
   rubocop-rake
   rubocop-rspec
   rubocop-slim!

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,200 @@
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
+AllCops:
+  Include:
+    - '**/*.slim'
+
+Layout/ArgumentAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/ArrayAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/BlockAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/ClosingParenthesisIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Lint/EmptyFile:
+  Exclude:
+    - '**/*.slim'
+
+Layout/EmptyLineAfterGuardClause:
+  Exclude:
+    - '**/*.slim'
+
+Layout/EndAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstArgumentIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstArrayElementIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstArrayElementLineBreak:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstHashElementIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstHashElementLineBreak:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstMethodArgumentLineBreak:
+  Exclude:
+    - '**/*.slim'
+
+Layout/FirstParameterIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/HashAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/IndentationConsistency:
+  Exclude:
+    - '**/*.slim'
+
+Layout/IndentationWidth:
+  Exclude:
+    - '**/*.slim'
+
+Layout/LineEndStringConcatenationIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/LineLength:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineArrayBraceLayout:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineAssignmentLayout:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineHashBraceLayout:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineMethodCallBraceLayout:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineMethodCallIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Exclude:
+    - '**/*.slim'
+
+Layout/MultilineOperationIndentation:
+  Exclude:
+    - '**/*.slim'
+
+Layout/ParameterAlignment:
+  Exclude:
+    - '**/*.slim'
+
+Layout/TrailingEmptyLines:
+  Exclude:
+    - '**/*.slim'
+
+Layout/TrailingWhitespace:
+  Exclude:
+    - '**/*.slim'
+
+Lint/UselessAssignment:
+  Exclude:
+    - '**/*.slim'
+
+Lint/Void:
+  Exclude:
+    - '**/*.slim'
+
+Metrics/BlockLength:
+  Exclude:
+    - '**/*.slim'
+
+Metrics/BlockNesting:
+  Exclude:
+    - '**/*.slim'
+
+Naming/FileName:
+  Exclude:
+    - '**/*.slim'
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - '**/*.slim'
+
+Style/IdenticalConditionalBranches:
+  Exclude:
+    - '**/*.slim'
+
+Style/IfUnlessModifier:
+  Exclude:
+    - '**/*.slim'
+
+Style/MultilineTernaryOperator:
+  Exclude:
+    - '**/*.slim'
+
+Style/NestedTernaryOperator:
+  Exclude:
+    - '**/*.slim'
+
+Style/Next:
+  Exclude:
+    - '**/*.slim'
+
+Style/ParallelAssignment:
+  Exclude:
+    - '**/*.slim'
+
+Style/RescueModifier:
+  Exclude:
+    - '**/*.slim'
+
+Style/Semicolon:
+  Exclude:
+    - '**/*.slim'
+
+Style/TrailingCommaInArguments:
+  Exclude:
+    - '**/*.slim'
+
+Style/TrailingCommaInArrayLiteral:
+  Exclude:
+    - '**/*.slim'
+
+Style/TrailingCommaInHashLiteral:
+  Exclude:
+    - '**/*.slim'
+
+Style/WhileUntilDo:
+  Exclude:
+    - '**/*.slim'
+
+Style/WhileUntilModifier:
+  Exclude:
+    - '**/*.slim'

--- a/lib/rubocop-slim.rb
+++ b/lib/rubocop-slim.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'rubocop/slim'

--- a/lib/rubocop/slim.rb
+++ b/lib/rubocop/slim.rb
@@ -1,3 +1,13 @@
 # frozen_string_literal: true
 
+module RuboCop
+  module Slim
+    autoload :ConfigLoader, 'rubocop/slim/config_loader'
+    autoload :RubyClip, 'rubocop/slim/ruby_clip'
+    autoload :RubyClipper, 'rubocop/slim/ruby_clipper'
+    autoload :RubyExtractor, 'rubocop/slim/ruby_extractor'
+  end
+end
+
+require_relative 'slim/rubocop_extension'
 require_relative 'slim/version'

--- a/lib/rubocop/slim/config_loader.rb
+++ b/lib/rubocop/slim/config_loader.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Slim
+    # Merge default RuboCop config with plugin config.
+    class ConfigLoader
+      PLUGIN_CONFIG_PATH = ::File.expand_path(
+        '../../../config/default.yml',
+        __dir__
+      )
+
+      class << self
+        # @return [RuboCop::Config]
+        def call
+          new.call
+        end
+      end
+
+      # @return [RuboCop::Config]
+      def call
+        RuboCop::ConfigLoader.merge_with_default(
+          plugin_config,
+          PLUGIN_CONFIG_PATH
+        )
+      end
+
+      private
+
+      # @return [RuboCop::Config]
+      def plugin_config
+        config = ::RuboCop::Config.new(
+          plugin_config_hash,
+          PLUGIN_CONFIG_PATH
+        )
+        config.make_excludes_absolute
+        config
+      end
+
+      # @return [Hash]
+      def plugin_config_hash
+        ::RuboCop::ConfigLoader.send(
+          :load_yaml_configuration,
+          PLUGIN_CONFIG_PATH
+        )
+      end
+    end
+  end
+end

--- a/lib/rubocop/slim/rubocop_extension.rb
+++ b/lib/rubocop/slim/rubocop_extension.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+RuboCop::Runner.ruby_extractors.unshift(RuboCop::Slim::RubyExtractor)
+
+RuboCop::ConfigLoader.instance_variable_set(
+  :@default_configuration,
+  RuboCop::Slim::ConfigLoader.call
+)

--- a/lib/rubocop/slim/ruby_clip.rb
+++ b/lib/rubocop/slim/ruby_clip.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Slim
+    RubyClip = ::Struct.new(
+      :code,
+      :offset,
+      keyword_init: true
+    )
+  end
+end

--- a/lib/rubocop/slim/ruby_clipper.rb
+++ b/lib/rubocop/slim/ruby_clipper.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Slim
+    # Remove unnecessary part (e.g. `if`, `unless`, `do`, ...) from Ruby-ish code.
+    class RubyClipper
+      class << self
+        # @param [String] code
+        # @return [Hash]
+        def call(code)
+          new(code).call
+        end
+      end
+
+      # @param [String] code
+      def initialize(code)
+        @code = code
+      end
+
+      # @return [RuboCop::Slim::RubyClip]
+      def call
+        [
+          PrecedingKeywordRemover,
+          TrailingDoRemover
+        ].reduce(
+          RubyClip.new(
+            code: @code,
+            offset: 0
+          )
+        ) do |previous, callable|
+          result = callable.call(previous.code)
+          RubyClip.new(
+            code: result.code,
+            offset: previous.offset + result.offset
+          )
+        end
+      end
+
+      # Remove preceding keyword.
+      class PrecedingKeywordRemover
+        REGEXP = /
+          \A
+          (?:
+            begin
+            | case
+            | else
+            | elsif
+            | ensure
+            | if
+            | rescue
+            | unless
+            | until
+            | when
+            | while
+            | for[ \t]+\w+[ \t]+in
+          )
+          [ \t]
+        /x.freeze
+
+        class << self
+          # @param [String] code
+          # @return [RubyClip]
+          def call(code)
+            new(code).call
+          end
+        end
+
+        # @param [String] code
+        def initialize(code)
+          @code = code
+        end
+
+        # @return [Hash]
+        def call
+          data = @code.match(REGEXP)
+          if data
+            offset = data[0].length
+            RubyClip.new(
+              code: @code[offset..],
+              offset: offset
+            )
+          else
+            RubyClip.new(
+              code: @code,
+              offset: 0
+            )
+          end
+        end
+      end
+
+      # Remove trailing `do`.
+      class TrailingDoRemover
+        REGEXP = /
+          [ \t]
+          do
+          [ \t]*
+          (\|[^|]*\|)?
+          [ \t]*
+          \Z
+        /x.freeze
+
+        class << self
+          # @param [String] code
+          # @return [RubyClip]
+          def call(code)
+            new(code).call
+          end
+        end
+
+        # @param [String] code
+        def initialize(code)
+          @code = code
+        end
+
+        # @return [Hash]
+        def call
+          RubyClip.new(
+            code: @code.sub(REGEXP, ''),
+            offset: 0
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/slim/ruby_extractor.rb
+++ b/lib/rubocop/slim/ruby_extractor.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'slimi'
+
+module RuboCop
+  module Slim
+    # Extract Ruby codes from Slim template.
+    class RubyExtractor
+      class << self
+        # @param [RuboCop::ProcessedSource] processed_source
+        # @return [Array<RuboCop::ProcessedSource>, nil]
+        def call(processed_source)
+          new(processed_source).call
+        end
+      end
+
+      # @param [RuboCop::ProcessedSource] processed_source
+      def initialize(processed_source)
+        @processed_source = processed_source
+      end
+
+      # @return [Array<RuboCop::ProcessedSource>, nil]
+      def call
+        return unless supported_file_path_pattern?
+
+        ruby_ranges.map do |(begin_, end_)|
+          clip = RubyClipper.new(template_source[begin_...end_]).call
+          ::RuboCop::ProcessedSource.new(
+            clip[:code],
+            @processed_source.ruby_version,
+            file_path,
+            offset: begin_ + clip[:offset]
+          )
+        end
+      end
+
+      private
+
+      # @return [Array] Slim AST, represented in S-expression.
+      def ast
+        ::Slimi::Filters::Interpolation.new.call(
+          ::Slimi::Parser.new(file: file_path).call(template_source)
+        )
+      end
+
+      # @return [String, nil]
+      def file_path
+        @processed_source.path
+      end
+
+      # @return [Array<Array<Integer>>]
+      def ruby_ranges
+        result = []
+        traverse(ast) do |begin_, end_|
+          result << [begin_, end_]
+        end
+        result
+      end
+
+      # @return [Boolean]
+      def supported_file_path_pattern?
+        file_path&.end_with?('.slim')
+      end
+
+      def traverse(node, &block)
+        return unless node.instance_of?(::Array)
+
+        block.call(node[2], node[3]) if node[0] == :slimi && node[1] == :position
+        node.each do |element|
+          traverse(element, &block)
+        end
+      end
+
+      # @return [String]
+      def template_source
+        @processed_source.raw_source
+      end
+    end
+  end
+end

--- a/rubocop-slim.gemspec
+++ b/rubocop-slim.gemspec
@@ -28,4 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.add_dependency 'rubocop', '~> 1.32'
+  spec.add_dependency 'slimi', '~> 0.7'
 end

--- a/spec/fixtures/dummy.slim
+++ b/spec/fixtures/dummy.slim
@@ -1,0 +1,8 @@
+- "a"
+= b
+| #{"c"}
+- a = 1
+- a if array.size > 0
+- a if !b
+- a if !b # rubocop:disable Style/NegatedIf
+- if "a"

--- a/spec/rubocop/slim/ruby_extractor_spec.rb
+++ b/spec/rubocop/slim/ruby_extractor_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Slim::RubyExtractor do
+  describe '.call' do
+    subject do
+      described_class.call(processed_source)
+    end
+
+    let(:processed_source) do
+      RuboCop::ProcessedSource.new(
+        source,
+        3.1,
+        file_path
+      )
+    end
+
+    let(:file_path) do
+      'dummy.slim'
+    end
+
+    let(:source) do
+      <<~SLIM
+        a
+        = b
+        - array.each do |element|
+          = element
+      SLIM
+    end
+
+    context 'with valid condition' do
+      it 'returns Ruby codes with offset' do
+        result = subject
+        expect(result.length).to eq(3)
+        expect(result[0].raw_source).to eq('b')
+        expect(result[0].offset).to eq(4)
+        expect(result[0].file_path).to eq(file_path)
+        expect(result[1].raw_source).to eq('array.each')
+        expect(result[1].offset).to eq(8)
+        expect(result[2].raw_source).to eq('element')
+        expect(result[2].offset).to eq(36)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This extenison allows `rubocop` to work for slim templates.

```
$ bundle exec rubocop spec/fixtures/dummy.slim
Inspecting 1 file
C

Offenses:

spec/fixtures/dummy.slim:1:3: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
- "a"
  ^^^
spec/fixtures/dummy.slim:3:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
| #{"c"}
    ^^^
spec/fixtures/dummy.slim:5:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of size > 0.
- a if array.size > 0
       ^^^^^^^^^^^^^^
spec/fixtures/dummy.slim:6:3: C: [Correctable] Style/NegatedIf: Favor unless over if for negative conditions.
- a if !b
  ^^^^^^^
spec/fixtures/dummy.slim:8:6: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
- if "a"
     ^^^

1 file inspected, 5 offenses detected, 5 offenses autocorrectable
```