### PR TITLE
Fix bug on keyword only line (e.g. `else`)

### DIFF
--- a/lib/rubocop/slim/keyword_remover.rb
+++ b/lib/rubocop/slim/keyword_remover.rb
@@ -49,7 +49,7 @@ module RuboCop
             | while
             | for[ \t]+\w+[ \t]+in
           )
-          [ \t]
+          \b[ \t]*
         /x.freeze
 
         class << self

--- a/spec/rubocop/slim/ruby_extractor_spec.rb
+++ b/spec/rubocop/slim/ruby_extractor_spec.rb
@@ -57,5 +57,25 @@ RSpec.describe RuboCop::Slim::RubyExtractor do
         expect(result[1][:offset]).to eq(10)
       end
     end
+
+    context 'with `else`' do
+      let(:source) do
+        <<~SLIM
+          - if a
+            p b
+          - else
+            p c
+        SLIM
+      end
+
+      it 'returns Ruby codes for a and b' do
+        result = subject
+        expect(result.length).to eq(2)
+        expect(result[0][:processed_source].raw_source).to eq('a')
+        expect(result[0][:offset]).to eq(5)
+        expect(result[1][:processed_source].raw_source).to eq('')
+        expect(result[1][:offset]).to eq(19)
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolve https://github.com/r7kamura/rubocop-slim/issues/9