### PR TITLE
Fix syntax errors for do blocks with trailing code comments

### DIFF
--- a/lib/rubocop/slim/keyword_remover.rb
+++ b/lib/rubocop/slim/keyword_remover.rb
@@ -91,6 +91,7 @@ module RuboCop
           [ \t]*
           (\|[^|]*\|)?
           [ \t]*
+          (\#.*)?
           \Z
         /x.freeze
 

--- a/spec/rubocop/slim/ruby_extractor_spec.rb
+++ b/spec/rubocop/slim/ruby_extractor_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe RuboCop::Slim::RubyExtractor do
       end
     end
 
+    context 'with trailing code comments after do block' do
+      let(:source) do
+        <<~HAML
+          - array.each do |element| # code comment
+            = element
+        HAML
+      end
+
+      it 'returns Ruby codes with offset' do
+        result = subject
+        expect(result.length).to eq(2)
+        expect(result[0][:processed_source].raw_source).to eq('array.each')
+        expect(result[0][:offset]).to eq(2)
+        expect(result[1][:processed_source].raw_source).to eq('element')
+        expect(result[1][:offset]).to eq(45)
+      end
+    end
+
     context 'with `when a, b`' do
       let(:source) do
         <<~SLIM


### PR DESCRIPTION
Same with:

- https://github.com/r7kamura/rubocop-haml/pull/5