### PR TITLE
Exclude `Style/RedundantParentheses` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -175,6 +175,10 @@ Style/ParallelAssignment:
   Exclude:
     - '**/*.slim'
 
+Style/RedundantParentheses:
+  Exclude:
+    - '**/*.slim'
+
 Style/RescueModifier:
   Exclude:
     - '**/*.slim'


### PR DESCRIPTION
- Resolve https://github.com/r7kamura/rubocop-slim/issues/37